### PR TITLE
cupida: Link older libutils for camerahalserver

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -40,7 +40,7 @@ function blob_fixup {
             "$PATCHELF" --replace-needed libutils.so libutils_v32.so "$2"
             ;;
         vendor/bin/hw/camerahalserver)
-            "${PATCHELF}" --replace-needed "libutils.so" "libutils_v32.so" "${2}"
+            "${PATCHELF}" --replace-needed "libutils.so" "libutils-v31.so" "${2}"
             "${PATCHELF}" --replace-needed "libbinder.so" "libbinder_v32.so" "${2}"
             "${PATCHELF}" --replace-needed "libhidlbase.so" "libhidlbase_v32.so" "${2}"
             ;;


### PR DESCRIPTION
- in common as need for both of devices https://github.com/oplus-ossi-development/android_device_oplus_mt6893-common/commit/c30d594ac3d0dbfcabfa26409aaf309a63c13c72